### PR TITLE
Potential fix for code scanning alert no. 56: Server-side request forgery

### DIFF
--- a/vercel-api/app/api/catbox/route.ts
+++ b/vercel-api/app/api/catbox/route.ts
@@ -13,9 +13,7 @@ interface RequestError {
 // Helper function to extract file ID from catbox URL
 function extractFileIdFromUrl(url: string): string | null {
   const patterns = [
-    /files\.catbox\.moe\/([^\/]+)/,
-    /catbox\.moe\/([^\/]+)/,
-    /^([a-zA-Z0-9]+\.[a-zA-Z0-9]+)$/
+    /^([a-zA-Z0-9]+\.[a-zA-Z0-9]+)$/, // Strictly match valid file IDs (e.g., "abc123.jpg")
   ];
   
   for (const pattern of patterns) {
@@ -127,8 +125,22 @@ export async function GET(request: NextRequest) {
     }
 
     // Extract the actual file ID if a full URL was provided
-    const actualFileId = extractFileIdFromUrl(fileId) || fileId;
+    const actualFileId = extractFileIdFromUrl(fileId);
     
+    if (!actualFileId) {
+      return NextResponse.json(
+        { error: "Invalid file parameter" },
+        { 
+          status: 400,
+          headers: {
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+            "Access-Control-Allow-Headers": "Content-Type",
+          },
+        }
+      );
+    }
+
     // Construct the catbox file URL
     const catboxUrl = `https://files.catbox.moe/${actualFileId}`;
     


### PR DESCRIPTION
Potential fix for [https://github.com/ZoneCog/elizaos-central/security/code-scanning/56](https://github.com/ZoneCog/elizaos-central/security/code-scanning/56)

To fix the SSRF vulnerability, we need to ensure that the user-provided `file` parameter is strictly validated and restricted to a predefined set of allowed values or patterns. Specifically:
1. Use a whitelist-based approach to validate the `file` parameter. For example, allow only specific file IDs or enforce a strict pattern that matches valid file IDs.
2. Reject any input that does not conform to the expected format or is not explicitly allowed.
3. Ensure that the `extractFileIdFromUrl` function is robust and does not allow bypassing the validation.

The changes will be made in the `GET` function and the `extractFileIdFromUrl` function to enforce stricter validation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
